### PR TITLE
feat: multi-scene world UX

### DIFF
--- a/src/components/LinkerPage/LinkerPage.tsx
+++ b/src/components/LinkerPage/LinkerPage.tsx
@@ -22,7 +22,8 @@ import { redirectToAuthDapp } from '../../modules/wallet/utils'
 import { Navbar } from '../Navbar'
 import Files from '../Files'
 import Map from '../Map'
-import { DeployWarning } from '../DeployWarning';
+import { LocationBadge } from '../Badges'
+import { DeployWarning } from '../DeployWarning'
 import DeploySuccess from '../DeploySuccess/DeploySuccess.container'
 import { Props } from './types'
 
@@ -35,7 +36,7 @@ enum Tab {
 
 export default function LinkScenePage(props: Props) {
   const [tab, setTab] = useState<Tab>(Tab.Map)
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(true)
   const {
     isConnected,
     wallet,
@@ -56,7 +57,8 @@ export default function LinkScenePage(props: Props) {
   const isTestNet = wallet?.chainId !== ChainId.ETHEREUM_MAINNET
   const networkName = isTestNet && `&NETWORK=sepolia`
   const networkDomain = isTestNet ? 'zone' : 'org'
-  const deployUrl = `https://play.decentraland.${networkDomain}/?position=${x},${y}${networkName}`
+  const realm = info?.world ? `&realm=${info.world}` : ''
+  const deployUrl = `https://play.decentraland.${networkDomain}/?position=${x},${y}${networkName}${realm}`
 
   useEffect(() => {
     onFetchInfo()
@@ -69,7 +71,9 @@ export default function LinkScenePage(props: Props) {
         <div className="warning-modal">
           <h2>Warning</h2>
           <DeployWarning />
-          <Button primary size="medium" onClick={() => setOpen(false)}>CONTINUE</Button>
+          <Button primary size="medium" onClick={() => setOpen(false)}>
+            CONTINUE
+          </Button>
         </div>
       </Modal>
       <Navbar />
@@ -97,10 +101,8 @@ export default function LinkScenePage(props: Props) {
                   deployUrl && window.open(deployUrl!, '_blank')?.focus()
                 }
               >
-                <Badge color={Color.SUMMER_RED}>
-                  <Icon name="point" />
-                  {x}, {y}
-                </Badge>
+                {info?.world && <LocationBadge world={info.world} />}
+                <LocationBadge baseParcel={{ x, y }} />
               </div>
               {!!isConnected && (
                 <div className="address-header">
@@ -143,7 +145,11 @@ export default function LinkScenePage(props: Props) {
         {!!(authorizations?.length && !isUpdateAuthorized) && (
           <Toast
             type={ToastType.ERROR}
-            title="Check LAND permissions"
+            title={
+              info?.isWorld
+                ? 'Check World permissions'
+                : 'Check LAND permissions'
+            }
             body="You dont have permissions to update some of the coords"
           />
         )}

--- a/src/components/LinkerPage/style.css
+++ b/src/components/LinkerPage/style.css
@@ -26,11 +26,12 @@
   padding-top: 24px;
 }
 
-.address-header {
-  margin-right: 16px;
+div.url {
+  display: flex;
+  margin-right: 0;
 }
 
-div.url > div.dcl.badge {
+div.url div.dcl.badge {
   cursor: pointer;
 }
 

--- a/src/components/ServerLogsPage/components/LogsCard.tsx
+++ b/src/components/ServerLogsPage/components/LogsCard.tsx
@@ -7,7 +7,7 @@ type LogsCardProps = {
 }
 
 export const LogsCard = ({ info }: LogsCardProps) => {
-  const worldName = info.world ? `${info.world}.dcl.eth` : 'Unknown World'
+  const worldName = info.world || 'Unknown World'
 
   return (
     <Container className="serverlogs-card-container">


### PR DESCRIPTION
## Description

Improved UX for multi-scene worlds deployment. Now UI shows world name and coordinates when deploying to a world.

Key changes:
- info.world previously was only the domain name (for example, for "example.dcl.eth", info.world was "example"), now it's expected to receive full world name. SDK related change: https://github.com/decentraland/js-sdk-toolchain/pull/1317

## Screenshots

Deploying to Multi-scene World BEFORE:
<img width="1512" height="903" alt="image" src="https://github.com/user-attachments/assets/b7bbbf64-15b4-450f-95cb-aa788e86bb41" />

Deploying to Multi-scene World AFTER:
<img width="1512" height="900" alt="image" src="https://github.com/user-attachments/assets/57472efc-0e78-4e6a-88e4-2241fc1f2819" />
