### PR TITLE
feat: add signature for deleting scenes from world

### DIFF
--- a/src/modules/server/reducer.ts
+++ b/src/modules/server/reducer.ts
@@ -49,6 +49,7 @@ export type Info = {
   world?: string
   action?: StorageAction
   targetUrl?: string
+  deleteScenesFromWorldPayload?: string
 }
 
 export type FileSize = {

--- a/src/modules/server/selectors.ts
+++ b/src/modules/server/selectors.ts
@@ -4,3 +4,4 @@ export const getFiles = (state: RootState) => state.api.files
 export const isLoading = (state: RootState) => !!state.api.loading.length
 export const getError = (state: RootState) => state.api.error
 export const getInfo = (state: RootState) => state.api.info
+export const getDeleteScenesFromWorldPayload = (state: RootState) => state.api.info?.deleteScenesFromWorldPayload

--- a/src/modules/server/types.ts
+++ b/src/modules/server/types.ts
@@ -13,6 +13,7 @@ export type InfoResponse = {
   skipValidations: boolean
   isPortableExperience: boolean
   isWorld: boolean
+  deleteScenesFromWorldPayload?: string
   // Storage fields
   storageType?: StorageType
   key?: string

--- a/src/modules/server/utils.ts
+++ b/src/modules/server/utils.ts
@@ -7,6 +7,7 @@ export type DeployScene =
       address: string
       authChain: AuthChain
       chainId: ChainId
+      deleteSignature?: string
     }
   | Record<string, never>
 

--- a/src/modules/signature/sagas.spec.ts
+++ b/src/modules/signature/sagas.spec.ts
@@ -18,6 +18,7 @@ import { call, select } from 'redux-saga/effects'
 import { putWorldACLRequest, deleteWorldACLRequest } from '../acl/actions'
 import { closeServer, postDeploy } from '../server/utils'
 import { fetchCatalystRequest } from '../server/actions'
+import { getDeleteScenesFromWorldPayload } from '../server/selectors'
 import {
   createIdentityFailure,
   createIdentityRequest,
@@ -96,8 +97,9 @@ describe('signature sagas', () => {
             [select(getIdentity), auth],
             [select(getAddress), address],
             [select(getChainId), chainId],
+            [select(getDeleteScenesFromWorldPayload), undefined],
             [
-              call(postDeploy, { authChain, address, chainId }),
+              call(postDeploy, { authChain, address, chainId, deleteSignature: undefined }),
               Promise.resolve(),
             ],
           ])
@@ -113,8 +115,9 @@ describe('signature sagas', () => {
               [select(getIdentity), auth],
               [select(getAddress), address],
               [select(getChainId), chainId],
+              [select(getDeleteScenesFromWorldPayload), undefined],
               [
-                call(postDeploy, { authChain, address, chainId }),
+                call(postDeploy, { authChain, address, chainId, deleteSignature: undefined }),
                 Promise.reject(new Error(error)),
               ],
             ])

--- a/src/modules/signature/sagas.ts
+++ b/src/modules/signature/sagas.ts
@@ -56,6 +56,7 @@ import {
 import { putWorldACLRequest, deleteWorldACLRequest } from '../acl/actions'
 import { signQuestsFetchRequest } from '../quests/action'
 import { getIdentity } from '../wallet/selectors'
+import { getDeleteScenesFromWorldPayload } from '../server/selectors'
 
 export function* signatureSaga() {
   yield takeLatest(SIGN_CONTENT_REQUEST, handleSignContentRequest)
@@ -112,10 +113,19 @@ function* handleSignContentRequest(action: SignContentRequestAction) {
 function* handleSignContentSuccess(action: SignContentSuccessAction) {
   const address: string = yield select(getAddress)
   const chainId: ChainId = yield select(getChainId)
+  const deleteScenesFromWorldPayload: string = yield select(getDeleteScenesFromWorldPayload)
   const { authChain } = action.payload
-
   try {
-    yield call(postDeploy, { authChain, address, chainId })
+    let deleteSignature: string | undefined
+    if (deleteScenesFromWorldPayload) {
+      const identity: AuthIdentity | undefined = yield select(getIdentity)
+      if (identity) {
+        const deleteAuthChain: AuthChain = Authenticator.signPayload(identity, deleteScenesFromWorldPayload)
+        deleteSignature = JSON.stringify(deleteAuthChain)
+      }
+    }
+
+    yield call(postDeploy, { authChain, address, chainId, deleteSignature })
     yield put(deploySuccess())
   } catch (error) {
     yield put(signContentFailure((error as Error).message))


### PR DESCRIPTION
## Summary

When deploying a World via the CLI **without `--multi-scene`**, existing scenes are deleted before deploying the new one, matching the default behavior of Creator Hub.

This PR adds support for the CLI to request the linker-dapp to sign a **DELETE payload** . The linker-dapp uses the existing `AuthIdentity` to sign both payloads.

---

## How It Works

1. The CLI checks whether the World already has scenes before opening the linker-dapp.
2. If scenes exist and the user confirms deletion, the CLI builds a `deleteScenesFromWorldPayload` and sends it via `/api/info`.
3. The linker-dapp reads the payload and signs it 
4. The signed auth chain is returned to the CLI as `deleteSignature`, alongside the regular `authChain` 
5. The CLI deletes the scenes on the world