### PR TITLE
feat: check lands permissions for worlds

### DIFF
--- a/src/components/LinkerPage/LinkerPage.container.tsx
+++ b/src/components/LinkerPage/LinkerPage.container.tsx
@@ -13,6 +13,7 @@ import {
   getData as getAuthorizations,
   isUpdateAuthorized,
   isLoading as isAuthorizationLoading,
+  getWorldWidePermission,
 } from '../../modules/authorization/selectors'
 import { signContentRequest } from '../../modules/signature/actions'
 import { RootState } from '../../types'
@@ -37,6 +38,7 @@ const mapState = (state: RootState): MapStateProps => {
     isSigning: isSigningTx(state),
     info: getInfo(state),
     deployError: state.signature.error,
+    worldWidePermission: getWorldWidePermission(state),
   }
 }
 

--- a/src/components/LinkerPage/LinkerPage.tsx
+++ b/src/components/LinkerPage/LinkerPage.tsx
@@ -51,9 +51,12 @@ export default function LinkScenePage(props: Props) {
     signed,
     info,
     deployError,
+    worldWidePermission,
   } = props
 
   const { x, y } = info?.baseParcel || { x: 0, y: 0 }
+  const needsWorldWide = info?.isWorld && !info?.multiScene
+  const missingWorldWidePermission = needsWorldWide && worldWidePermission === false
   const isTestNet = wallet?.chainId !== ChainId.ETHEREUM_MAINNET
   const networkName = isTestNet && `&NETWORK=sepolia`
   const networkDomain = isTestNet ? 'zone' : 'org'
@@ -129,7 +132,7 @@ export default function LinkScenePage(props: Props) {
                     isSigning ||
                     (isConnected && isAuthorizationLoading)
                   }
-                  disabled={isConnected && !isUpdateAuthorized}
+                  disabled={isConnected && (!isUpdateAuthorized || missingWorldWidePermission)}
                   onClick={
                     isConnected
                       ? () => onSignContent(info!.rootCID)
@@ -142,7 +145,14 @@ export default function LinkScenePage(props: Props) {
             )}
           </HeaderMenu>
         </Container>
-        {!open && !!(authorizations?.length && !isUpdateAuthorized) && (
+        {!open && missingWorldWidePermission && (
+          <Toast
+            type={ToastType.ERROR}
+            title="World-wide permission required"
+            body="Non-multi-scene deployments require world-wide deployment permission. Contact the world owner or use --multi-scene."
+          />
+        )}
+        {!open && !missingWorldWidePermission && !!(authorizations?.length && !isUpdateAuthorized) && (
           <Toast
             type={ToastType.ERROR}
             title={

--- a/src/components/LinkerPage/LinkerPage.tsx
+++ b/src/components/LinkerPage/LinkerPage.tsx
@@ -142,7 +142,7 @@ export default function LinkScenePage(props: Props) {
             )}
           </HeaderMenu>
         </Container>
-        {!!(authorizations?.length && !isUpdateAuthorized) && (
+        {!open && !!(authorizations?.length && !isUpdateAuthorized) && (
           <Toast
             type={ToastType.ERROR}
             title={

--- a/src/components/LinkerPage/style.css
+++ b/src/components/LinkerPage/style.css
@@ -38,6 +38,7 @@ div.url div.dcl.badge {
 .dcl.toast.warn,
 .dcl.toast.error {
   margin-left: 0;
+  max-width: 100%;
 }
 
 .dcl.toast.error {

--- a/src/components/LinkerPage/types.ts
+++ b/src/components/LinkerPage/types.ts
@@ -21,6 +21,7 @@ export type Props = {
   onSignContent: (cid: string) => SignContentRequestAction
   onFetchFiles: () => void
   deployError?: string | null
+  worldWidePermission?: boolean
 }
 
 export type MapStateProps = Pick<
@@ -35,6 +36,7 @@ export type MapStateProps = Pick<
   | 'isSigning'
   | 'info'
   | 'deployError'
+  | 'worldWidePermission'
 >
 export type MapDispatchProps = Pick<
   Props,

--- a/src/components/Map/style.css
+++ b/src/components/Map/style.css
@@ -1,5 +1,5 @@
 .map-table {
-  max-height: 200px;
+  max-height: 300px;
   overflow-y: scroll;
 }
 .permission-not-granted {

--- a/src/modules/authorization/actions.ts
+++ b/src/modules/authorization/actions.ts
@@ -7,8 +7,8 @@ export const FETCH_AUTHORIZATIONS_FAILURE = '[Failure] Fetch LAND Authorizations
 
 export const fetchAuthorizationsRequest = (owner: string) => action(FETCH_AUTHORIZATIONS_REQUEST, { owner })
 
-export const fetchAuthorizationsSuccess = (authorizations: Authorization[]) =>
-  action(FETCH_AUTHORIZATIONS_SUCCESS, { authorizations })
+export const fetchAuthorizationsSuccess = (authorizations: Authorization[], worldWidePermission?: boolean) =>
+  action(FETCH_AUTHORIZATIONS_SUCCESS, { authorizations, worldWidePermission })
 
 export const fetchAuthorizationsFailure = (error: string) => action(FETCH_AUTHORIZATIONS_FAILURE, { error })
 

--- a/src/modules/authorization/reducer.ts
+++ b/src/modules/authorization/reducer.ts
@@ -16,12 +16,14 @@ export type AuthorizationState = {
   data: any
   loading: LoadingState
   error: string | null
+  worldWidePermission?: boolean
 }
 
 export const INITIAL_STATE: AuthorizationState = {
   data: [],
   loading: [],
   error: null,
+  worldWidePermission: undefined,
 }
 
 export type AuthorizationReducerAction =
@@ -44,6 +46,7 @@ export const authorizationReducer = (
         loading: loadingReducer(state.loading, action),
         data: action.payload.authorizations,
         error: null,
+        worldWidePermission: action.payload.worldWidePermission,
       }
     case FETCH_AUTHORIZATIONS_FAILURE:
       return {

--- a/src/modules/authorization/sagas.ts
+++ b/src/modules/authorization/sagas.ts
@@ -26,7 +26,28 @@ function* handleFetchAuthorizationsRequest() {
     info = yield select(getInfo)
   }
 
-  if (info.skipValidations) {
+  if (info.isWorld) {
+    try {
+      const address: string = yield select(getAddress)
+      const response: Response = yield call(fetch, `/api/world-parcel-permissions/${address}`)
+      if (response.ok) {
+        const authorizations: Authorization[] = yield call([response, response.json])
+        yield put(fetchAuthorizationsSuccess(authorizations))
+      } else {
+        yield put(
+          fetchAuthorizationsSuccess(
+            info.parcels.map(({ x, y }) => ({
+              x,
+              y,
+              isUpdateAuthorized: true,
+            }))
+          )
+        )
+      }
+    } catch (error) {
+      yield put(fetchAuthorizationsFailure((error as Error).message))
+    }
+  } else if (info.skipValidations) {
     try {
       const { parcels } = info
       yield put(

--- a/src/modules/authorization/sagas.ts
+++ b/src/modules/authorization/sagas.ts
@@ -31,8 +31,8 @@ function* handleFetchAuthorizationsRequest() {
       const address: string = yield select(getAddress)
       const response: Response = yield call(fetch, `/api/world-parcel-permissions/${address}`)
       if (response.ok) {
-        const authorizations: Authorization[] = yield call([response, response.json])
-        yield put(fetchAuthorizationsSuccess(authorizations))
+        const data: { authorizations: Authorization[]; worldWidePermission: boolean } = yield call([response, response.json])
+        yield put(fetchAuthorizationsSuccess(data.authorizations, data.worldWidePermission))
       } else {
         yield put(
           fetchAuthorizationsSuccess(

--- a/src/modules/authorization/selectors.ts
+++ b/src/modules/authorization/selectors.ts
@@ -18,3 +18,5 @@ export const isUpdateAuthorized = createSelector(getData, authorizations => {
 
   return authorizations.every((a: Authorization) => a.isUpdateAuthorized)
 })
+
+export const getWorldWidePermission = createSelector(getState, state => state.worldWidePermission)

--- a/src/modules/server/reducer.ts
+++ b/src/modules/server/reducer.ts
@@ -49,6 +49,7 @@ export type Info = {
   world?: string
   action?: StorageAction
   targetUrl?: string
+  multiScene?: boolean
   deleteScenesFromWorldPayload?: string
 }
 

--- a/src/modules/server/types.ts
+++ b/src/modules/server/types.ts
@@ -22,4 +22,5 @@ export type InfoResponse = {
   world?: string
   action?: StorageAction
   targetUrl?: string
+  multiScene?: boolean
 }


### PR DESCRIPTION
## Add world parcel permission checks before signing                                  
                                                                                                                                                                             
- When deploying to a world, the linker-dapp now fetches real per-parcel permissions from the backend after wallet connection, instead of blindly marking all parcels as "Granted"            
- Each parcel in the table shows "Granted" or "Not granted" based on the wallet's actual permissions                                                                                     
- If the wallet lacks permission on any parcel, the "Sign & Deploy" button is disabled and an error toast is shown                                                                            
- Falls back to all-granted if the permissions endpoint is unavailable    