### PR TITLE
fix: improve rendering performance

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-PUBLIC_URL=""

--- a/src/components/LinkerPage/LinkerPage.tsx
+++ b/src/components/LinkerPage/LinkerPage.tsx
@@ -4,7 +4,6 @@ import {
   Footer,
   Page,
   Header,
-  Icon,
   Button,
   Container,
   HeaderMenu,
@@ -196,6 +195,7 @@ export default function LinkScenePage(props: Props) {
             authorizations={authorizations}
             parcels={info!.parcels}
             baseParcel={info!.baseParcel}
+            showAtlas={!info.isWorld} // Linker dapp doesn't have access to a world layout, so we only show the atlas for genesis city.
           />
         )}
       </Page>

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,62 +1,139 @@
-import './style.css'
-import { Atlas, Container, Coord, Layer, Section, Table } from 'decentraland-ui'
+import React, { useCallback, useMemo, useState } from 'react'
+import {
+  Atlas,
+  Container,
+  Coord,
+  Layer,
+  Pagination,
+  Section,
+  Table,
+} from 'decentraland-ui'
+import { Authorization } from '../../modules/authorization/types'
 import { Props } from './types'
+import './style.css'
 
-export default function LinkScenePage({ authorizations, parcels, baseParcel }: Props) {
-  const find = <T extends Coord>(coords: T[]) => (x: number, y: number): T | undefined =>
-    coords.find(s => s.x === x && s.y === y)
+const formatCoord = (coord: Coord) => `${coord.x},${coord.y}`
 
-  const selectedFillLayer: Layer = (x: number, y: number) => {
-    return find(parcels)(x, y) ? { color: '#ff99', scale: 1.2 } : null
-  }
+const ITEMS_PER_PAGE = 1000
 
-  const selectedStroke: Layer = (x: number, y: number) => {
-    return find(parcels)(x, y) ? { color: '#ff0044', scale: 1.4 } : null
-  }
+function LinkScenePage({
+  authorizations,
+  parcels,
+  baseParcel,
+  showAtlas = false,
+}: Props) {
+  const [page, setPage] = useState(1)
+
+  const parcelsSet = useMemo(() => new Set(parcels.map(formatCoord)), [parcels])
+  const authorizationsMap = useMemo(
+    () => new Map(authorizations.map((auth) => [formatCoord(auth), auth])),
+    [authorizations],
+  )
+
+  const totalPages = Math.max(1, Math.ceil(parcels.length / ITEMS_PER_PAGE))
+
+  const pageParcels = useMemo(() => {
+    const start = (page - 1) * ITEMS_PER_PAGE
+    return parcels
+      .slice(start, start + ITEMS_PER_PAGE)
+      .map((coords, index) => ({ coords, index: start + index + 1 }))
+  }, [parcels, page])
+
+  const findAuthorization = useCallback(
+    (x: number, y: number): Authorization | undefined => {
+      return authorizationsMap.get(formatCoord({ x, y }))
+    },
+    [authorizationsMap],
+  )
+
+  const hasParcel = useCallback(
+    (x: number, y: number): boolean => parcelsSet.has(formatCoord({ x, y })),
+    [parcelsSet],
+  )
+
+  const selectedFillLayer: Layer = useCallback(
+    (x: number, y: number) => {
+      return hasParcel(x, y) ? { color: '#ff99', scale: 1.2 } : null
+    },
+    [hasParcel],
+  )
+
+  const selectedStroke: Layer = useCallback(
+    (x: number, y: number) => {
+      return hasParcel(x, y) ? { color: '#ff0044', scale: 1.4 } : null
+    },
+    [hasParcel],
+  )
 
   return (
     <Container>
       {!!parcels.length && (
-        <Section size="large" className="map-table">
-          <Table basic="very">
-            <Table.Header>
-              <Table.Row>
-                <Table.HeaderCell>Name</Table.HeaderCell>
-                <Table.HeaderCell>Coordinates</Table.HeaderCell>
-                <Table.HeaderCell>Permissions</Table.HeaderCell>
-              </Table.Row>
-            </Table.Header>
+        <Section size="large">
+          <div className="map-table">
+            <Table basic="very">
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell>Name</Table.HeaderCell>
+                  <Table.HeaderCell>Coordinates</Table.HeaderCell>
+                  <Table.HeaderCell>Permissions</Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
 
-            <Table.Body>
-              {parcels.map((coords, index) => {
-                const isAuthorized = !!find(authorizations || [])(coords.x, coords.y)?.isUpdateAuthorized
-                return (
-                  <Table.Row key={index}>
-                    <Table.Cell>Parcel {index}</Table.Cell>
-                    <Table.Cell>
-                      {coords.x}, {coords.y}
-                    </Table.Cell>
-                    <Table.Cell className={!isAuthorized ? 'permission-not-granted' : ''}>
-                      {authorizations.length ? (isAuthorized ? 'Granted' : 'Not granted') : ''}
-                    </Table.Cell>
-                  </Table.Row>
-                )
-              })}
-            </Table.Body>
-          </Table>
+              <Table.Body>
+                {pageParcels.map(({ coords, index }) => {
+                  const isAuthorized = !!findAuthorization(coords.x, coords.y)
+                    ?.isUpdateAuthorized
+                  return (
+                    <Table.Row key={index}>
+                      <Table.Cell>Parcel {index}</Table.Cell>
+                      <Table.Cell>
+                        {coords.x}, {coords.y}
+                      </Table.Cell>
+                      <Table.Cell
+                        className={
+                          !isAuthorized ? 'permission-not-granted' : ''
+                        }
+                      >
+                        {authorizations.length
+                          ? isAuthorized
+                            ? 'Granted'
+                            : 'Not granted'
+                          : ''}
+                      </Table.Cell>
+                    </Table.Row>
+                  )
+                })}
+              </Table.Body>
+            </Table>
+          </div>
+          {totalPages > 1 && (
+            <div className="map-table-pagination">
+              <Pagination
+                activePage={page}
+                totalPages={totalPages}
+                onPageChange={(_, data) => setPage(Number(data.activePage))}
+                firstItem={null}
+                lastItem={null}
+              />
+            </div>
+          )}
         </Section>
       )}
-      <Container>
-        <Section size="large" className="map-canvas">
-          <Atlas
-            height={300}
-            x={baseParcel.x}
-            y={baseParcel.y}
-            isDraggable={false}
-            layers={[selectedStroke, selectedFillLayer]}
-          />
-        </Section>
-      </Container>
+      {showAtlas && (
+        <Container>
+          <Section size="large" className="map-canvas">
+            <Atlas
+              height={300}
+              x={baseParcel.x}
+              y={baseParcel.y}
+              isDraggable={false}
+              layers={[selectedStroke, selectedFillLayer]}
+            />
+          </Section>
+        </Container>
+      )}
     </Container>
   )
 }
+
+export default React.memo(LinkScenePage)

--- a/src/components/Map/style.css
+++ b/src/components/Map/style.css
@@ -3,9 +3,15 @@
   overflow-y: scroll;
 }
 .permission-not-granted {
-  color: brown
+  color: brown;
 }
 
 .map-canvas > div {
-  height: unset !important
+  height: 300px !important;
+}
+
+.map-table-pagination {
+  display: flex;
+  justify-content: center;
+  margin-top: 40px;
 }

--- a/src/components/Map/types.ts
+++ b/src/components/Map/types.ts
@@ -6,6 +6,7 @@ export type Props = {
   authorizations: Authorization[]
   parcels: Coord[]
   baseParcel: Coord
+  showAtlas?: boolean
 }
 export type MapStateProps = Props
 export type MapDispatchProps = Props


### PR DESCRIPTION
## What does this PR do?

Improves the Map component rendering performance and adds pagination support for scenes with large numbers of parcels.

## Changes

- **O(1) lookups:** Replace linear `.find()` scans with `Set` (parcels) and `Map` (authorizations) for constant-time coordinate lookups.
- **Memoization:** Wrap layer callbacks and derived data with `useCallback` / `useMemo`, and export the component with `React.memo` to prevent unnecessary re-renders.
- **Parcel table pagination:** Paginate the parcels table (1,000 items per page) so large scenes don't render thousands of table rows at once.
- **Conditional Atlas:** Add a `showAtlas` prop to hide the Atlas map for worlds, since the linker dapp doesn't have access to world layouts.
- **Cleanup:** Remove unused `Icon` import, delete unused `.env` file, and fix minor CSS issues (missing semicolons, explicit map canvas height).

## Screenshots

LAND:
<img width="1512" height="900" alt="image" src="https://github.com/user-attachments/assets/41f252c4-0467-422a-9df5-50fd5cc6707f" />

World (with 2000 parcels):
<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/8ed3252b-802f-42e9-8ff5-83a59bb40d0f" />
